### PR TITLE
Add missing schema-dts import in JsonLd example

### DIFF
--- a/skills/seo-aeo-best-practices/references/structured-data.md
+++ b/skills/seo-aeo-best-practices/references/structured-data.md
@@ -142,6 +142,8 @@ const pageSchema = {
 ## Implementation in Next.js
 
 ```typescript
+import { Thing, WithContext } from 'schema-dts'
+
 // Component to render JSON-LD
 // Ensure data comes from trusted sources (your CMS).
 // If data could contain user-generated content, strip HTML tags


### PR DESCRIPTION
The `JsonLd` component example in `structured-data.md` uses `Thing` in its type signature but never imports it from `schema-dts`. Every other code block in the file imports the types it uses — this one was missing. Added the import to match.